### PR TITLE
Revert mail container entrypoint

### DIFF
--- a/mail/Dockerfile
+++ b/mail/Dockerfile
@@ -22,4 +22,4 @@ COPY pop3server.xml /root/conf
 RUN chmod +x /root/startup.sh
 RUN chmod +x /root/initialdata.sh
 
-ENTRYPOINT ["/bin/bash", "/root/startup.sh"]
+ENTRYPOINT ["./startup.sh"]


### PR DESCRIPTION
Original failure to start entrypoint was due to wrong EOL conversion by Git. 
Linux shell scripts' LF EOL was automatically changed to Windows-style CRLF, causing the hashbang line `#!/bin/bash` parsing to fail.