### PR TITLE
Add AWS resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,79 @@
+resource "aws_vpc" "wan" {
+  cidr_block = "10.0.0.0/16"
+
+  tags = {
+    Name = "TOC WAN VPC"
+  }
+}
+
+resource "aws_subnet" "public_subnets" {
+  count      = length(var.public_subnet_cidrs)
+  vpc_id     = aws_vpc.wan.id
+  cidr_block = element(var.public_subnet_cidrs, count.index)
+  availability_zone = element(var.azs, count.index)
+
+  tags = {
+    Name = "Public Subnet ${count.index + 1}"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.wan.id
+
+  tags = {
+    Name = "TOC IGW"
+  }
+}
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.wan.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "Public Route Table"
+  }
+}
+
+resource "aws_route_table_association" "public_subnet_asso" {
+  count = length(var.public_subnet_cidrs)
+  subnet_id      = element(aws_subnet.public_subnets[*].id, count.index)
+  route_table_id = aws_route_table.public_rt.id
+}
+
+resource "aws_network_interface" "site_nis" {
+  count      = length(var.site_ips)
+  subnet_id   = element(aws_subnet.public_subnets[*].id, count.index)
+  private_ips = slice(var.site_ips, count.index, count.index+1)
+
+  tags = {
+    Name = "primary_network_interface"
+  }
+}
+
+resource "aws_security_group" "toc_controller_sg" {
+  name        = "ec2_security_group"
+  description = "Controls access to the main and stepup TOC controller EC2 instances"
+  vpc_id      = aws_vpc.wan.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 data "aws_ami" "ubuntu" {
   most_recent = true
 
@@ -23,10 +99,12 @@ locals {
     instance1 = {
       ami           = data.aws_ami.ubuntu.id
       instance_type = "t2.micro"
+      user_data     = "${path.module}/provision/ubuntu22.sh"
     }
     instance2 = {
       ami           = data.aws_ami.ubuntu.id
       instance_type = "t2.micro"
+      user_data     = "${path.module}/provision/ubuntu22.sh"
     }
   }
 }
@@ -42,6 +120,14 @@ resource "aws_instance" "this" {
   instance_type               = each.value.instance_type
   key_name                    = aws_key_pair.ssh_key.key_name
   associate_public_ip_address = true
+  count                       = length(var.site_ips)
+  subnet_id                   = element(aws_subnet.public_subnets[*].id, count.index)
+  network_interface {
+    network_interface_id      = element(aws_network_interface.site_nis[*].id, count.index)
+    device_index              = 0
+  }
+  vpc_security_group_ids      = ["toc_controller_sg"]
+  user_data                   = file(each.value.user_data)
 
   tags = {
     Name = each.key

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = "~> 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.8.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "ap-southeast-1" # Asia Pacific (Singapore)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,21 @@
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "Public Subnet CIDR values"
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "azs" {
+  type        = list(string)
+  description = "Availability Zones"
+  default     = ["ap-southeast-1a", "ap-southeast-1b"]
+}
+
+variable "site_ips" {
+  type        = list(string)
+  description = ""
+  default     = ["10.0.1.1", "10.0.2.1"]
+}
+
 variable "public_key" {
   type        = string
   description = "Path to the public ssh key"


### PR DESCRIPTION
1. Add Amazon Web Services EC2 instances for main and stepup site in 2 availability zones in `ap-southeast-1` (**Singapore**) region
2. Includes virtual private cloud (VPC), public subnets for Availability Zones, Internet gateway, routing tables and security group.